### PR TITLE
Adiciona a página de Dojos na Wiki

### DIFF
--- a/docs/entrega_III/extras/dojos.md
+++ b/docs/entrega_III/extras/dojos.md
@@ -1,0 +1,27 @@
+# Dojo
+
+## 1. Histórico de versão
+
+<center>
+
+| Versão | Data       | Descrição                                          | Autor        |
+| ------ | ---------- | -------------------------------------------------- | ------------ |
+| 0.1    | 04/03/2022 | Criação da documentação sobre Dojo e adição do vídeo sobre NextJS | Victor Gonçalves |
+
+</center>
+
+## 2. Definição
+
+&emsp;&emsp;_Dojo_ é uma palavra de origem japonesa, que basicamente quer dizer "local de treinamento". No contexto da engenharia de _software_, especificamente em ambientes colaborativos, o Dojo é uma técnica de dissiminação de conhecimento através da interação entre os membros da equipe. Existem diversas variantes desta técnica sendo postas em prática pela comunidade de _software_. Notavelmente, dentre às variantes de aplicação do Dojo, está a variante _Kata_, onde um membro do time assume a figura de apresentador demonstrando uma solução pronta desenvolvida anteriormente.
+
+## 3. Dojo sobre Next JS
+
+&emsp;&emsp;Uma vez que se foi acordado o uso da tecnologia _NextJS_ no projeto, notou-se a conveniencia da execução de um Dojo sobre ela. Neste Dojo, foi-se utilizado o formato _Kata_, porém, meramente expositivo. Isto é, não houveram dinâmicas de resolução de problemas. O apresentador é o Paulo Victor, e neste Dojo ele apresenta alguns conceitos chaves sobre a tecnologia e detalhes pertinentes ao contexto do projeto.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/k3dx-v-A1XE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+Estiveram presentes durante o Dojo os membros: Paulo Victor, Daniel Barcelos, Denys Rogeres, Thiago Mesquita e Victor Gonçalves; os demais que não puderam participar, tiveram a oportunidade de assistir o Dojo na íntegra posteriormente.
+
+## 4. Referências
+
+BONFIM, Márcio. O que é o Coding Dojo. **DevMedia - Plataforma para programadores**, 2014. Disponível em <https://www.devmedia.com.br/o-que-e-o-coding-dojo/30517>. Acesso em: 04 de fev. de 2022.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,11 +63,12 @@ nav:
     - Iniciativas extras:
       - Reorganização da Documentação: entrega_II/extras/docs_refactor.md
       - Melhoria do Protótipo de Alta Fidelidade: entrega_II/extras/prototipo_alta_fidelidade.md
-      - Atas: 
+      - Atas:
         - 09/02 - Reunião de Planning: entrega_II/extras/atas/ata_0902.md
         - 17/02 - Reunião de Feedback: entrega_II/extras/atas/ata_1702.md
   - Desenho de Software (Padrões de Projeto):
     - Iniciativas extras:
       - Guia de contribuição: entrega_III/extras/contribuicao.md
+      - Dojos: entrega_III/extras/dojos.md
   - Apresentações: apresentacoes/index.md
 dev_addr: "0.0.0.0:8000"


### PR DESCRIPTION
# Descrição
- Adiciona a página de Dojos na Wiki, expondo e explicando.

## Como revisar
- Procurar por erros de ortografia, verificar se o iFrame do vídeo está funcionando corretamente